### PR TITLE
Fix PNG dimension parsing to handle big-endian

### DIFF
--- a/MareSynchronos/Utils/PngHdr.cs
+++ b/MareSynchronos/Utils/PngHdr.cs
@@ -20,7 +20,7 @@ public class PngHdr
 
 			stream.ReadExactly(buffer[..8]);
 
-			uint ihdrLength = BitConverter.ToUInt32(buffer);
+			uint ihdrLength = ReadBigEndianUInt32(buffer[..4]);
 
 			// The next four bytes will be the length of the IHDR section (it should be 13 bytes but we only need 8)
 			if (ihdrLength < 8)
@@ -32,8 +32,8 @@ public class PngHdr
 
 			stream.ReadExactly(buffer[..8]);
 
-			uint width = BitConverter.ToUInt32(buffer);
-			uint height = BitConverter.ToUInt32(buffer[4..]);
+			uint width = ReadBigEndianUInt32(buffer[..4]);
+			uint height = ReadBigEndianUInt32(buffer[4..8]);
 
 			// Validate the width/height are non-negative and... that's all we care about!
 			if (width > int.MaxValue || height > int.MaxValue)
@@ -46,4 +46,12 @@ public class PngHdr
 			return InvalidSize;
 		}
 	}
+    // Minimal helper for big-endian conversion
+    private static uint ReadBigEndianUInt32(ReadOnlySpan<byte> bytes)
+    {
+        return ((uint)bytes[0] << 24) |
+               ((uint)bytes[1] << 16) |
+               ((uint)bytes[2] << 8) |
+               bytes[3];
+    }
 }


### PR DESCRIPTION
Corrected PngHdr to read width/height in big-endian, fixing 256+ px images