### PR TITLE
Fix health check, reconnect automatically on error

### DIFF
--- a/MareSynchronos/WebAPI/SignalR/ApiController.cs
+++ b/MareSynchronos/WebAPI/SignalR/ApiController.cs
@@ -315,8 +315,8 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase, IM
         {
             await Task.Delay(TimeSpan.FromSeconds(30), ct).ConfigureAwait(false);
             var healthy = await CheckClientHealth().ConfigureAwait(false);
-            Logger.LogDebug("Checking Client Health State returned {0}", healthy);
-            if (!healthy)
+            Logger.LogDebug("Checking Client Health State returned {0} and hub connection {1}", healthy, _mareHub.State == HubConnectionState.Connected);
+            if (!healthy || _mareHub.State != HubConnectionState.Connected)
             {
                 _unhealthy++;
                 if (_unhealthy > 1)


### PR DESCRIPTION
+ Made health check actually do something instead of just logging connection health issues.

+ Forcibly reconnects the client when they've had connection issues.

+ Requires server code change to enable the health check so it's not just returning false all the time and making users reconnect.